### PR TITLE
Change base URL for Shift Planning API

### DIFF
--- a/lib/shift_planning/connection.rb
+++ b/lib/shift_planning/connection.rb
@@ -4,7 +4,7 @@ class ShiftPlanning::Connection
   def initialize(key)
     @key = key
     @token = nil
-    @http = Faraday.new(url: "http://www.shiftplanning.com") do |conn|
+    @http = Faraday.new(url: "https://www.humanity.com") do |conn|
       conn.request :url_encoded
 
       conn.response :json

--- a/lib/shift_planning/version.rb
+++ b/lib/shift_planning/version.rb
@@ -1,3 +1,3 @@
 module ShiftPlanning
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
This commit fixes #2 by changing the base URL for the Shift Planning API. The old URL is no longer supported as of 3/4/2017. 